### PR TITLE
Gestion des erreurs 404 quand une route n'existe pas

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -28,6 +28,9 @@ fos_rest:
   format_listener:
     rules:
         - { path: '^/', priorities: ['json'], fallback_format: 'json' }
-
+  exception:
+        enabled: true
+        codes:
+           { App\Exception\ResourceValidationException: 400 }
 sensio_framework_extra:
   view: { annotations: false } // éviter les collisions avec l'annotation  @View  du FOSRestBundle

--- a/src/Exception/ResourceValidationException.php
+++ b/src/Exception/ResourceValidationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Exception;
+
+class ResourceValidationException extends \Exception
+{
+}


### PR DESCRIPTION
Ajout dans doctrine.yaml/fos_rest : 
  exception:
        enabled: true
        codes:
           { App\Exception\ResourceValidationException: 400 }
#35